### PR TITLE
HDDS-7260. Fix the issue that the "-du" command does not return correct disk consumed with replica for both ratis and EC

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -521,8 +521,12 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     OmKeyInfo keyInfo = status.getKeyInfo();
     short replication = (short) keyInfo.getReplicationConfig()
         .getRequiredNodes();
+    //calculate the number of bytes required to store the dataSize with replication
+    long diskConsumed = keyInfo.getReplicatedSize();
+
     return new FileStatusAdapter(
         keyInfo.getDataSize(),
+        diskConsumed,
         new Path(OZONE_URI_DELIMITER + keyInfo.getKeyName())
             .makeQualified(defaultUri, workingDir),
         status.isDirectory(),

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -944,8 +944,11 @@ public class BasicRootedOzoneClientAdapterImpl
     OmKeyInfo keyInfo = status.getKeyInfo();
     short replication = (short) keyInfo.getReplicationConfig()
         .getRequiredNodes();
+    //calculate the number of bytes required to store the dataSize with replication
+    long diskConsumed = keyInfo.getReplicatedSize();
     return new FileStatusAdapter(
         keyInfo.getDataSize(),
+        diskConsumed,
         new Path(ofsPathPrefix + OZONE_URI_DELIMITER + keyInfo.getKeyName())
             .makeQualified(defaultUri, workingDir),
         status.isDirectory(),
@@ -1048,7 +1051,7 @@ public class BasicRootedOzoneClientAdapterImpl
         UserGroupInformation.createRemoteUser(ozoneVolume.getOwner());
     String owner = ugi.getShortUserName();
     String group = getGroupName(ugi);
-    return new FileStatusAdapter(0L, path, true, (short)0, 0L,
+    return new FileStatusAdapter(0L, 0L, path, true, (short)0, 0L,
         ozoneVolume.getCreationTime().getEpochSecond() * 1000, 0L,
         FsPermission.getDirDefault().toShort(),
         owner, group, path,
@@ -1075,7 +1078,7 @@ public class BasicRootedOzoneClientAdapterImpl
               ozoneBucket.getName(), pathStr);
     }
     Path path = new Path(pathStr);
-    return new FileStatusAdapter(0L, path, true, (short)0, 0L,
+    return new FileStatusAdapter(0L, 0L, path, true, (short)0, 0L,
         ozoneBucket.getCreationTime().getEpochSecond() * 1000, 0L,
         FsPermission.getDirDefault().toShort(),
         owner, group, path, new BlockLocation[0]);
@@ -1090,7 +1093,7 @@ public class BasicRootedOzoneClientAdapterImpl
     // Note that most fields are mimicked from HDFS FileStatus for root,
     //  except modification time, permission, owner and group.
     Path path = new Path(uri.toString() + OZONE_URI_DELIMITER);
-    return new FileStatusAdapter(0L, path, true, (short)0, 0L,
+    return new FileStatusAdapter(0L, 0L, path, true, (short)0, 0L,
         System.currentTimeMillis(), 0L,
         FsPermission.getDirDefault().toShort(),
         null, null, null, new BlockLocation[0]

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
@@ -77,6 +77,10 @@ public final class FileStatusAdapter {
     return isdir;
   }
 
+  public boolean isFile() {
+    return !isdir;
+  }
+
   public short getBlockReplication() {
     return blockReplication;
   }
@@ -119,6 +123,29 @@ public final class FileStatusAdapter {
   @SuppressFBWarnings("EI_EXPOSE_REP")
   public BlockLocation[] getBlockLocations() {
     return blockLocations;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName())
+        .append("{")
+        .append("path=" + path)
+        .append("; isDirectory=" + isdir);
+    if(isFile()){
+      sb.append("; length=" + length)
+              .append("; diskConsumed= " + getDiskConsumed())
+          .append("; blockReplication=" + blockReplication)
+          .append("; blocksize=" + blocksize);
+    }
+    sb.append("; accessTime=" + accessTime)
+        .append("; owner=" + owner)
+        .append("; group=" + group)
+        .append("; permission=" + permission)
+        .append("; isSymlink=" + getSymlink())
+        .append("}");
+    
+    return sb.toString();
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
@@ -35,6 +35,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class FileStatusAdapter {
 
   private final long length;
+  private final long diskConsumed;
   private final Path path;
   private final boolean isdir;
   private final short blockReplication;
@@ -48,11 +49,12 @@ public final class FileStatusAdapter {
   private final BlockLocation[] blockLocations;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
-  public FileStatusAdapter(long length, Path path, boolean isdir,
+  public FileStatusAdapter(long length, long diskConsumed, Path path, boolean isdir,
       short blockReplication, long blocksize, long modificationTime,
       long accessTime, short permission, String owner,
       String group, Path symlink, BlockLocation[] locations) {
     this.length = length;
+    this.diskConsumed = diskConsumed;
     this.path = path;
     this.isdir = isdir;
     this.blockReplication = blockReplication;
@@ -111,6 +113,9 @@ public final class FileStatusAdapter {
     return length;
   }
 
+  public long getDiskConsumed() {
+    return diskConsumed;
+  }
   @SuppressFBWarnings("EI_EXPOSE_REP")
   public BlockLocation[] getBlockLocations() {
     return blockLocations;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the issue that the "-du" command does not return correct disk consumed with replica for both ratis and EC

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7260

## How was this patch tested?
Manual tests. (WIP)
Unit tests. (WIP)
Robot tests. (WIP)
